### PR TITLE
search for the virtualenv in parent directories up to the root/$HOME

### DIFF
--- a/dotpyvenv.plugin.zsh
+++ b/dotpyvenv.plugin.zsh
@@ -4,22 +4,46 @@ dotpyvenv:current_dir_has_virtualenv_folder(){
     echo "$(pwd)" | grep "$(dirname "$VIRTUAL_ENV")" > /dev/null 2>&1
 }
 
-dotpyvenv:source() {
+# Find the virtualenv in the current directory or any parent up to the root or $HOME
+function dotpyvenv:find_venv()
+{
     local DOTPYVENV_DIR=".pyvenv"
     local DOTPYVENV_FILE=".pyvenvdir"
+    local dir="$1"
 
+    while true; do
+        local ENV_DIR="${dir}/${DOTPYVENV_DIR}"
+        local ENV_FILE="${dir}/${DOTPYVENV_FILE}"
+
+        if [[ -f "${ENV_DIR}/bin/activate" ]]; then
+            printf "${ENV_DIR}"
+            break
+
+        elif [[ -f "${ENV_FILE}" ]]; then
+            ENV_DIR="${dir}/$(cat ${ENV_FILE})"
+
+            if [[ -f "${ENV_DIR}/bin/activate" ]]; then
+                printf "${ENV_DIR}"
+                break
+            fi
+        fi
+
+        [[ "$dir" != "/" && $dir != "$HOME" ]] || break
+        dir=$(dirname "$dir")
+    done
+}
+
+
+dotpyvenv:source() {
     if [ -n "$VIRTUAL_ENV"  ]; then
         dotpyvenv:current_dir_has_virtualenv_folder || deactivate
 
-    elif [ -f "${DOTPYVENV_FILE}" ]; then
-        DOTPYVENV_DIR="$(cat "${DOTPYVENV_FILE}")"
+    else
+        local venv_path=$(dotpyvenv:find_venv $PWD)
 
-        [ -f "${DOTPYVENV_DIR}/bin/activate" ] && {
-            source "${DOTPYVENV_DIR}/bin/activate"
-        }
-
-    elif [ -f "${DOTPYVENV_DIR}/bin/activate" ]; then
-        source "${DOTPYVENV_DIR}/bin/activate"
+        if [[ -n "$venv_path" ]]; then
+            source "${venv_path}/bin/activate"
+        fi
     fi
 }
 


### PR DESCRIPTION
With the current release if you change directly into a subdirectory of where your venv is located, it doesn't get activated. ie, if you have `x/`, `x/.pyvenv`, `x/subdir` and you `cd x/subdir`, the venv is not activated.

This change searches all the parent directories up to the root or $HOME looking for .pyvenv / .pyvenvdir, so you can cd directory to a subdirectory successfully.